### PR TITLE
feat : BottomActionBar 컴포넌트 추가 및 댓글 API 연동

### DIFF
--- a/frontend/.claude/settings.json
+++ b/frontend/.claude/settings.json
@@ -20,8 +20,7 @@
       "Bash(sudo:*)",
       "Bash(git init:*)",
       "Bash(git clone:*)",
-      "Bash(git add:*)",
-      "Bash(git commit:*)",
+
       "Bash(git push:*)",
       "Bash(git pull:*)",
       "Bash(git fetch:*)",

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -46,6 +46,7 @@ storybook-static
 # claude code 
 # /.claude/*
 # /cc/*
+/cc/input/*
 
 # sample
 /src/samples/*

--- a/frontend/cc/ans/260628-ans-003-TourAPI_적용_구상.md
+++ b/frontend/cc/ans/260628-ans-003-TourAPI_적용_구상.md
@@ -1,0 +1,597 @@
+# 한국관광공사 TourAPI — 일출 프로젝트 적용 구상
+
+> 작성일: 2026-06-28  
+> 근거 문서: `cc/input/260628-input-001-한국관광공사_TourAPI_개방데이터_매뉴얼_통합정리.md`  
+> 수정일: 2026-06-28 — 공공데이터 DB 저장 금지 규약 반영, contentId 저장 방식 및 BFF 호출 구조 추가
+
+---
+
+## 오퍼레이션 요약 — 응답 주요 필드 & 일출 프로젝트 활용 방안
+
+### 공통 오퍼레이션 (웰니스 · 의료 · 반려동물 3개 서비스 모두 제공)
+
+| 오퍼레이션 | 주요 응답 필드 | 일출 프로젝트 활용 방안 |
+|---|---|---|
+| `areaBasedList` | `contentid`, `title`, `addr1`, `firstimage`, `mapx`, `mapy`, `contentTypeId` | 지역 선택 시 해당 지역 장소 목록 조회 (검색 필터 · 지역 탐색) |
+| `locationBasedList` | `contentid`, `title`, `addr1`, `firstimage`, `mapx`, `mapy`, `dist`(거리m) | 사용자 GPS 기반 주변 장소 추천 (메인 화면 · 코스 생성 장소 추천) |
+| `searchKeyword` | `contentid`, `title`, `addr1`, `firstimage`, `mapx`, `mapy`, `contentTypeId` | 키워드 검색 결과 목록 (검색 피처) |
+| `detailCommon` | `title`, `addr1`, `addr2`, `tel`, `overview`, `firstimage`, `mapx`, `mapy`, `homepage` | 장소 상세 기본 정보 (이름·주소·전화·소개·좌표) |
+| `detailIntro` | 콘텐츠 타입별 상이 (예: `usetime` 운영시간, `usefee` 입장료, `parking` 주차) | 장소 상세 탭 — 운영시간·이용요금 등 카테고리별 안내 |
+| `detailImage` | `originimgurl`, `smallimageurl`, `imgname` | 장소 상세 이미지 갤러리 |
+
+**응답 예시 (`locationBasedList` 단일 아이템)**
+```json
+{
+  "contentid": "126508",
+  "title": "북한산 국립공원",
+  "addr1": "서울특별시 강북구 우이동",
+  "firstimage": "http://tong.visitkorea.or.kr/cms/resource/image.jpg",
+  "mapx": "127.0117",
+  "mapy": "37.6596",
+  "dist": "1240.5",
+  "contentTypeId": "76"
+}
+```
+
+---
+
+### 서비스별 전용 오퍼레이션
+
+| 서비스 | 오퍼레이션 | 주요 응답 필드 | 일출 프로젝트 활용 방안 |
+|---|---|---|---|
+| 웰니스 | `wellnessTursmSyncList` | `contentid`, `modifiedtime` | ⛔ DB 저장 금지 규약으로 사용 불가 |
+| 웰니스 | `detailIntro` (웰니스 전용) | `goodstay`, `hanok`, `benikia` 등 웰니스 인증 정보 | 감정 상태 "지치고 기운없음" 장소 추천 시 웰니스 인증 배지 표시 |
+| 반려동물 | `detailPetTour2` | `acmpyTypeCd`(동반유형), `acmpyPsblCpam`(동반가능동물), `acmpyNeedMtr`(준비물) | 반려동물 동반 가능 여부 뱃지 · 조건 안내 |
+| 반려동물 | `petTourSyncList2` | `contentid`, `modifiedtime` | ⛔ DB 저장 금지 규약으로 사용 불가 |
+| 반려동물 | `ldongCode2` | `ldongCd`(법정동코드), `ldongAddr`(법정동명) | 지역 필터 드롭다운 코드 목록 |
+| 반려동물 | `lclsSystmCode2` | `code`, `name` (대·중·소분류) | 카테고리 필터 코드 목록 |
+
+> **의료관광 서비스(`MdclTursmService`) 전용 오퍼레이션은 적용 제외** — 서비스 목적이 외국인 의료기관 안내로 일출 앱과 방향이 다름.
+
+**응답 예시 (`detailCommon` 기반 장소 상세 통합)**
+```json
+{
+  "contentid": "126508",
+  "title": "북한산 국립공원",
+  "addr1": "서울특별시 강북구 우이동",
+  "addr2": "우이분소",
+  "tel": "02-909-0497",
+  "overview": "서울 도심 속 자연 치유 공간...",
+  "firstimage": "http://tong.visitkorea.or.kr/cms/.../image.jpg",
+  "mapx": "127.0117",
+  "mapy": "37.6596"
+}
+```
+
+---
+
+### 코스 저장 시 DB 구조 (contentId만 저장)
+
+```
+plan_places 테이블
+┌──────────┬───────────┬───────┐
+│  planId  │ contentId │ order │
+├──────────┼───────────┼───────┤
+│   plan1  │  "126508" │   1   │  ← 숫자 식별자만 저장
+│   plan1  │  "234719" │   2   │  ← 장소명·주소·이미지 없음
+└──────────┴───────────┴───────┘
+코스 조회 시 → contentId별 detailCommon 실시간 호출 → 렌더링
+```
+
+---
+
+## 서비스별 예시 장소 — 실제 API 호출 흐름
+
+### 웰니스 관광정보 서비스 (`WellnessTursmService`)
+
+> 예시 장소: **센텀시티 스파랜드** (contentId: `702551`)
+
+#### Step 1. 장소 목록 조회 (`locationBasedList` 또는 `searchKeyword`)
+
+```
+# 키워드 "스파"로 검색
+GET http://apis.data.go.kr/B551011/WellnessTursmService/searchKeyword
+  ?serviceKey=인증키&keyword=스파&contentTypeId=12&arrange=C&langDivCd=KOR&_type=json
+```
+
+```json
+// 응답
+{
+  "response": {
+    "body": {
+      "items": {
+        "item": [
+          {
+            "contentId": "702551",
+            "contentTypeId": "12",
+            "baseAddr": "부산광역시 해운대구 센텀남대로 35 (우동)",
+            "zipCd": "48058",
+            "orgImage": "http://tong.visitkorea.or.kr/cms/resource/02/3544802_image2_1.JPEG",
+            "thumbImage": "http://tong.visitkorea.or.kr/cms/resource/02/3544802_image3_1.JPEG"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+#### Step 2. 장소 상세 조회 (`detailCommon`)
+
+```
+GET http://apis.data.go.kr/B551011/WellnessTursmService/detailCommon
+  ?serviceKey=인증키&contentId=702551&langDivCd=KOR&_type=json
+```
+
+```json
+// 응답
+{
+  "response": {
+    "body": {
+      "items": {
+        "item": [
+          {
+            "contentId": "702551",
+            "contentTypeId": "12",
+            "title": "센텀시티 스파랜드",
+            "homepage": "https://www.shinsegae.com/store/entertainment/centum-spaland.do",
+            "tel": "",
+            "orgImage": "http://tong.visitkorea.or.kr/cms/..."
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+#### Step 3. 소개 정보 조회 (`detailIntro`)
+
+```
+GET http://apis.data.go.kr/B551011/WellnessTursmService/detailIntro
+  ?serviceKey=인증키&contentId=702551&contentTypeId=12&langDivCd=KOR&_type=json
+```
+
+```json
+// 응답
+{
+  "response": {
+    "body": {
+      "items": {
+        "item": [
+          {
+            "contentId": "702551",
+            "contentTypeId": "12",
+            "infocenter": "055-***-****",
+            "parking": "가능",
+            "restdate": "연중무휴",
+            "usetime": "상시 개방",
+            "accomcount": ""
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+#### Step 4. 이미지 조회 (`detailImage`)
+
+```
+GET http://apis.data.go.kr/B551011/WellnessTursmService/detailImage
+  ?serviceKey=인증키&contentId=702551&imageYN=Y&langDivCd=KOR&_type=json
+```
+
+```json
+// 응답
+{
+  "response": {
+    "body": {
+      "items": {
+        "item": [
+          {
+            "contentId": "702551",
+            "orgImage": "http://tong.visitkorea.or.kr/cms/resource/62/2661062_image2_1.JPG",
+            "imgname": "스파랜드 센텀시티_4",
+            "thumbImage": "http://tong.visitkorea.or.kr/cms/resource/62/2661062_image2_1.JPG",
+            "cpyrhtDivCd": "Type3",
+            "serialnum": "2661062_4"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+---
+
+### 반려동물 동반여행 서비스 (`KorPetTourService2`)
+
+> 예시 장소: **여의도한강공원** (contentId: `1059479`)
+
+#### Step 1. 장소 목록 조회 (`locationBasedList2`)
+
+```
+# 내 주변 1000m 이내
+GET http://apis.data.go.kr/B551011/KorPetTourService2/locationBasedList2
+  ?serviceKey=인증키&mapX=126.981611&mapY=37.568477&radius=1000&_type=json
+```
+
+```json
+// 응답
+{
+  "response": {
+    "body": {
+      "items": {
+        "item": [
+          {
+            "contentid": "264353",
+            "contenttypeid": "12",
+            "addr1": "서울특별시 종로구 인사동길 62 (관훈동)",
+            "dist": "793.71",
+            "firstimage": "http://tong.visitkorea.or.kr/cms/resource/03/3412103_image2_1.JPG",
+            "firstimage2": "http://tong.visitkorea.or.kr/cms/resource/03/3412103_image3_1.JPG",
+            "mapx": "126.985...",
+            "mapy": "37.573..."
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+#### Step 2. 공통정보 조회 (`detailCommon2`)
+
+```
+GET http://apis.data.go.kr/B551011/KorPetTourService2/detailCommon2
+  ?serviceKey=인증키&contentId=1059479&_type=json
+```
+
+```json
+// 응답
+{
+  "response": {
+    "body": {
+      "items": {
+        "item": [
+          {
+            "contentid": "1059479",
+            "contenttypeid": "12",
+            "title": "여의도한강공원",
+            "tel": "",
+            "homepage": "https://hangang.seoul.go.kr"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+#### Step 3. 소개정보 조회 (`detailIntro2`)
+
+```
+GET http://apis.data.go.kr/B551011/KorPetTourService2/detailIntro2
+  ?serviceKey=인증키&contentId=1059479&contentTypeId=12&_type=json
+```
+
+```json
+// 응답
+{
+  "response": {
+    "body": {
+      "items": {
+        "item": [
+          {
+            "contentid": "1059479",
+            "restdate": "연중무휴",
+            "usetime": "상시 개방",
+            "parking": "가능 (1,7...)",
+            "infocenter": "02-****-****~6"
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+#### Step 4. 반려동물 전용 정보 조회 (`detailPetTour2`) ← 핵심
+
+```
+GET http://apis.data.go.kr/B551011/KorPetTourService2/detailPetTour2
+  ?serviceKey=인증키&contentId=1059479&_type=json
+```
+
+```json
+// 응답 — 반려동물 서비스 전용 필드
+{
+  "response": {
+    "body": {
+      "items": {
+        "item": [
+          {
+            "contentid": "1059479",
+            "acmpyTypeCd": "전구역 동반가능",
+            "acmpyPsblCpam": "전 견종 동반 가능",
+            "acmpyNeedMtr": "목줄 착용",
+            "etcAcmpyInfo": "- 목줄은 2m 이내로 유지\n- 맹견의 경우, 입마개 착용 필수\n- 배변봉투 지참 및 배변처리 필수",
+            "relaAcdntRiskMtr": "",
+            "relaPosesFclty": "",
+            "relaPurcPrdlst": ""
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+> **일출 프로젝트 활용**: `acmpyTypeCd`(동반 가능 구역), `acmpyPsblCpam`(동반 가능 견종), `acmpyNeedMtr`(필요 준비물)을 장소 상세 카드에 "반려동물 동반 조건" 섹션으로 표시.
+
+---
+
+### 서비스별 오퍼레이션 명칭 차이 주의
+
+| 오퍼레이션 | 웰니스 | 반려동물 |
+|---|---|---|
+| 지역기반 목록 | `areaBasedList` | `areaBasedList2` |
+| 위치기반 목록 | `locationBasedList` | `locationBasedList2` |
+| 키워드 검색 | `searchKeyword` | `searchKeyword2` |
+| 공통정보 | `detailCommon` | `detailCommon2` |
+| 소개정보 | `detailIntro` | `detailIntro2` |
+| 이미지 | `detailImage` | `detailImage2` |
+| 반복정보 | `detailInfo` | `detailInfo2` |
+| 서비스 전용 | — | `detailPetTour2` |
+| 법정동 코드 | `ldongCode` | `ldongCode2` |
+| 분류체계 코드 | — | `lclsSystmCode2` |
+
+> 반려동물 서비스는 모든 오퍼레이션명에 `2`가 붙는다. BFF route 구현 시 `service` 파라미터로 웰니스/반려동물 분기 처리 필요.
+
+---
+
+## 1. 현황 요약
+
+현재 일출 앱의 장소 데이터는 전부 `src/shared/data/mockData.ts`의 하드코딩 목데이터에 의존하고 있다.  
+TourAPI를 연동하면 **실데이터 기반의 장소 목록·검색·상세정보**를 제공할 수 있다.
+
+**활용 TourAPI 서비스**
+
+| 서비스 | 서비스ID | 특화 콘텐츠 | 적용 여부 |
+|---|---|---|---|
+| 웰니스 관광정보 | `WellnessTursmService` | 힐링·치유 여행 특화 장소 | ✅ 적용 |
+| 반려동물 동반여행 | `KorPetTourService2` | 반려동물 동반 가능 장소 | ✅ 적용 |
+| 의료 관광정보 | `MdclTursmService` | 의료관광 병원·클리닉 | ❌ 제외 |
+
+> **의료관광 서비스 제외 이유**: 외국인 대상 국내 의료기관 정보 제공이 목적으로, 힐링 여행 코스 기획이라는 일출 앱의 서비스 방향과 결이 다름. 응답 데이터도 영문 기반이며 병원·클리닉 정보 위주로 코스 구성 요소로 부적합.
+
+**공통 핵심 오퍼레이션 (3개 서비스 모두 제공)**
+
+| 오퍼레이션 | 메서드 | 주요 파라미터 |
+|---|---|---|
+| `areaBasedList` | GET | areaCode, sigunguCode, contentTypeId |
+| `locationBasedList` | GET | mapX, mapY, radius (GPS 기반) |
+| `searchKeyword` | GET | keyword, areaCode, contentTypeId |
+| `detailCommon` | GET | contentId → 이름, 주소, 전화, 좌표, 대표이미지 |
+| `detailIntro` | GET | contentId → 운영시간, 입장료 등 카테고리별 소개 |
+| `detailImage` | GET | contentId → 이미지 목록 |
+
+---
+
+## 2. 피처별 적용 구상
+
+### 2-1. 장소 검색 (`features/search`)
+
+**현재**: UI 컴포넌트만 존재, API 미연동  
+**적용**: `searchKeyword` 오퍼레이션으로 실시간 검색 연동
+
+```
+사용자 키워드 입력
+  → Next.js API route /api/tour/search?keyword=&areaCode=
+  → TourAPI searchKeyword (웰니스 OR 반려동물 OR 공통)
+  → 결과 카드 렌더링
+```
+
+**필터 구성안**
+- 카테고리 필터: `contentTypeId` (관광지/숙박/음식점/레포츠 등)
+- 지역 필터: `areaCode` (시도) + `sigunguCode` (시군구)
+- 서비스 필터: 웰니스 전용 / 반려동물 동반 가능
+
+---
+
+### 2-2. 내 주변 인기 장소 (`features/main`)
+
+**현재**: `/api/place/popular` → 목데이터 반환  
+**적용**: `locationBasedList`로 사용자 GPS 기반 실데이터 교체
+
+```
+사용자 위치 (mapX, mapY) 획득
+  → /api/tour/nearby?mapX=&mapY=&radius=5000
+  → TourAPI locationBasedList
+  → 기존 PopularPlace 타입에 매핑
+```
+
+**매핑 필드**
+| TourAPI 응답 | 현재 PopularPlace 타입 |
+|---|---|
+| `title` | `name` |
+| `firstimage` | `image` |
+| `addr1` | `location` |
+| `dist` | (거리 뱃지 신규 추가 가능) |
+| `contentTypeId` | `category` |
+
+---
+
+### 2-3. 코스 생성 장소 추천 (`features/course-creation`)
+
+**현재**: `RECOMMENDED_PLACES` 하드코딩 목데이터  
+**적용**: 감정 설문 결과 → contentTypeId 매핑 → `locationBasedList` or `searchKeyword`
+
+**감정 → 웰니스 카테고리 매핑 제안**
+
+| 감정 상태 | 추천 장소 유형 | contentTypeId | 서비스 |
+|---|---|---|---|
+| 지치고 기운없음 | 온천·스파·자연치유 | 웰니스 소개정보 참고 | WellnessTursmService |
+| 울적하고 속상함 | 공원·숲길·해안 | A01 (자연) | 공통 |
+| 답답하고 짜증남 | 레포츠·액티비티 | A03 (레포츠) | 공통 |
+| 무기력·재미없음 | 문화시설·전시 | A02 (문화시설) | 공통 |
+| 기분 좋음 | 맛집·쇼핑·명소 | A05 (음식), A04 (쇼핑) | 공통 |
+| 생각 정리 필요 | 사찰·한옥·서원 | A0201 (역사관광지) | 공통 |
+| 멍한 느낌 | 바다·호수·섬 | A0101 (자연관광지) | 공통 |
+
+이동수단·이동시간 파라미터 → `locationBasedList`의 `radius` 값으로 변환  
+(도보 1시간 → radius 약 3000m, 자가용 상관없음 → radius 50000m)
+
+---
+
+### 2-4. 장소 상세 (`features/place-detail`)
+
+**현재**: `PlaceDetail` 타입이 수동 정의, mock 데이터  
+**적용**: contentId 기반으로 3개 오퍼레이션 병렬 호출
+
+```
+/api/tour/place/[contentId]
+  → Promise.all([
+      detailCommon(contentId),   // 기본 정보
+      detailIntro(contentId),    // 운영시간·입장료
+      detailImage(contentId),    // 이미지 목록
+    ])
+  → PlaceDetail 타입으로 통합 반환
+```
+
+**현재 PlaceDetail 타입 ↔ TourAPI 필드 매핑**
+
+| 현재 타입 필드 | TourAPI 필드 |
+|---|---|
+| `name` | `detailCommon.title` |
+| `images` | `detailImage.originimgurl[]` |
+| `location.address` | `detailCommon.addr1 + addr2` |
+| `coordinates.lat/lng` | `detailCommon.mapy / mapx` |
+| `phone` | `detailCommon.tel` |
+| `operatingHours` | `detailIntro` (콘텐츠 타입별 상이) |
+| `description` | `detailCommon.overview` |
+
+---
+
+### 2-5. 반려동물 동반 필터 (신규 기능 제안)
+
+`KorPetTourService2`는 반려동물 동반 가능 여부·조건을 별도 필드로 제공.  
+`detailPetTour` 오퍼레이션에서 `acmpyTypeCd`(동반유형), `relaAcmpyAt`(동반가능여부) 등 반환.
+
+**적용 위치**: 검색 필터에 "반려동물 동반 가능" 토글 추가 → 해당 서비스로 라우팅
+
+---
+
+## 3. 공공데이터 이용 규약
+
+> **공공데이터포털 API는 응답 데이터를 서비스 DB에 직접 저장·복제하는 것이 금지되어 있다.**  
+> 모든 장소 정보는 사용자 요청 시점에 TourAPI를 실시간 호출하여 제공해야 한다.
+
+### 허용 / 금지 기준
+
+| 구분 | 허용 | 금지 |
+|---|---|---|
+| 캐싱 | 요청 단위 인메모리 캐시 (React Query staleTime, Redis TTL 수 분) | 장소명·주소·이미지 등 TourAPI 응답값을 서비스 DB 테이블에 저장 |
+| 식별자 저장 | 코스에 연결된 `contentId`(숫자 식별자)만 DB 저장 | contentId로 조회한 상세 데이터(title, addr, image 등) DB 저장 |
+| 동기화 | — | `syncList` 오퍼레이션으로 데이터를 주기적으로 수집·적재하는 파이프라인 |
+
+### 아키텍처 영향
+
+- **코스 저장 방식**: 코스 내 장소는 `contentId`만 저장. 코스 조회 시 각 contentId로 TourAPI를 실시간 호출해 장소 정보 렌더링.
+- **일 1,000건 한도가 더 중요해짐**: DB 버퍼 없이 실시간 호출이므로, React Query `staleTime` 설정으로 동일 contentId의 중복 호출 최소화 필수.
+- **장소 상세 3개 병렬 호출**: 상세 페이지 1회 진입 = 3건 소모(`detailCommon` + `detailIntro` + `detailImage`). 페이지 이탈 후 재진입 시 캐시 재활용 필수.
+- **`syncList` 오퍼레이션 사용 불가**: 변경된 항목을 탐지해 DB에 적재하는 용도이므로, 이 규약 하에서 실질적 활용 방법이 없음.
+
+### contentId 저장 방식 상세
+
+`contentId`는 TourAPI 내부의 숫자 키(예: `126508`)로, 콘텐츠(장소명·주소·이미지)가 아닌 **식별자**이므로 DB 저장이 허용된다.  
+유튜브 영상 URL을 즐겨찾기에 저장하는 것이 콘텐츠 복제가 아닌 것과 같은 원리.
+
+```
+DB에 저장되는 것 (허용)
+├── plan { id, userId, name, date }
+└── plan_places { planId, contentId: "126508", order: 1 }
+                            ↑ 숫자 식별자만 (장소명·주소·이미지 없음)
+
+코스 조회 시 (실시간 호출)
+└── contentId → /api/tour/place/[contentId] → TourAPI → 장소 정보 렌더링
+```
+
+**실용적 리스크**: TourAPI에서 해당 장소가 삭제되면 contentId로 정보를 불러올 수 없음.  
+→ 조회 실패 시 "장소 정보를 불러올 수 없습니다" fallback 처리로 대응.
+
+---
+
+## 4. API 호출 방향 — BFF vs 클라이언트 직접 호출
+
+**서버(BFF) 경유를 권장한다.**
+
+### 결정적 이유: 서비스키 보안
+
+클라이언트에서 TourAPI를 직접 호출하면 브라우저 네트워크 탭에 `serviceKey`가 그대로 노출된다.  
+유출된 키로 타인이 일 1,000건 한도를 소진하면 **서비스 전체가 당일 TourAPI를 사용할 수 없게 된다.**
+
+```
+# 클라이언트 직접 호출 시 — 누구나 키를 볼 수 있음
+https://apis.data.go.kr/B551011/WellnessTursmService/locationBasedList
+  ?serviceKey=ABC123XYZ...   ← 노출
+```
+
+### 비교
+
+| 항목 | 클라이언트 직접 | 서버(BFF) 경유 |
+|---|---|---|
+| 서비스키 보안 | 노출됨 | `.env`에서만 관리 |
+| CORS | TourAPI 허용 여부에 따라 불안정 | 서버→서버 호출로 CORS 무관 |
+| 응답 가공 | TourAPI 원본 구조 그대로 사용 | 프로젝트 타입에 맞게 변환 후 반환 |
+| 캐싱 | 브라우저 캐시만 | `Cache-Control` 헤더로 서버 레벨 캐싱 추가 가능 |
+| API 교체 | 모든 feature 파일 수정 필요 | BFF route 1곳만 수정 |
+
+> 현재 프로젝트가 이미 `/api/place/popular`, `/api/plan/popular` 등 BFF 패턴을 사용 중이므로 기존 구조와도 일치한다.
+
+---
+
+## 5. BFF API Route 설계안 (Next.js API Route)
+
+Next.js API route를 프록시로 두어 서비스키를 서버에서만 관리.
+
+```
+src/app/api/tour/
+├── search/route.ts            # searchKeyword (서비스 파라미터로 분기)
+├── nearby/route.ts            # locationBasedList
+├── area/route.ts              # areaBasedList
+└── place/[contentId]/route.ts # detailCommon + detailIntro + detailImage 통합
+```
+
+> `sync/route.ts`는 DB 저장 금지 규약으로 인해 설계에서 제외.
+
+**공통 처리 사항**
+- `serviceKey`는 `.env`의 `TOUR_API_KEY`로 관리 (클라이언트 노출 금지)
+- 응답은 JSON(`&_type=json`)으로 요청
+- `MobileApp=ilchul`, `MobileOS=ETC` 고정
+- BFF route 응답에 `Cache-Control: max-age=300` 헤더 설정으로 서버 레벨 단기 캐싱 활용
+
+---
+
+## 5. 구현 우선순위 제안
+
+| 순위 | 피처 | 이유 |
+|---|---|---|
+| 1 | 코스 생성 장소 추천 | 앱의 핵심 가치, 감정→장소 흐름이 실데이터로 완성됨 |
+| 2 | 장소 검색 | UI가 이미 존재, API만 연결하면 즉시 동작 |
+| 3 | 내 주변 인기 장소 | 메인 화면 실데이터화, GPS 연동 이미 있음 |
+| 4 | 장소 상세 | contentId 기반 상세정보 완성 |
+| 5 | 반려동물 동반 필터 | 차별화 기능, 추후 확장 |
+
+---
+
+## 6. 주의사항
+
+- **DB 저장 금지**: TourAPI 응답 데이터(장소명, 주소, 이미지 등)를 서비스 DB에 저장하지 않는다. `contentId`(식별자)만 저장 허용
+- **개발계정 한도**: 오퍼레이션별 일 1,000건. DB 버퍼 없이 실시간 호출이므로 React Query `staleTime` 설정으로 중복 호출 최소화 필수
+- **XML→JSON**: 반드시 `&_type=json` 추가, 누락 시 XML 파싱 오류
+- **contentTypeId 분류**: 웰니스·의료 서비스는 일반 관광 contentTypeId와 다를 수 있음 (서비스별 코드표 별도 확인 필요)
+- **syncList 사용 불가**: `wellnessTursmSyncList`, `petTourSyncList`는 DB 적재 파이프라인용 오퍼레이션 — DB 저장 금지 규약으로 활용 불가
+- **운영계정 전환**: 실서비스 전 한국관광공사 담당자 승인 필요 (1~3일), 미리 신청 권장

--- a/frontend/cc/ans/260628-ans-004-Claude_Code_작업완료_알림_설정.md
+++ b/frontend/cc/ans/260628-ans-004-Claude_Code_작업완료_알림_설정.md
@@ -1,0 +1,110 @@
+# Claude Code 작업완료 알림 설정 가이드
+
+Claude가 작업을 완료하거나 확인 요청이 발생했을 때, macOS 알림과 소리로 알려주는 훅 설정 방법입니다.
+
+---
+
+## 최종 동작 방식
+
+| 이벤트 | 소리 | 알림 제목 | 알림 내용 | 버튼 |
+|--------|------|-----------|-----------|------|
+| 작업 완료 (`Stop`) | Glass | `Claude Code ✅ 작업완료` | `프로젝트명: 채팅 제목` | 보기 |
+| 확인 요청 (`PermissionRequest`) | Ping | `Claude Code ⚠️ 확인 필요` | `프로젝트명: 채팅 제목` | - |
+
+- **보기** 버튼 클릭 시 Cursor 창이 foreground로 올라옴
+- 알림은 30초 후 자동으로 사라짐
+
+---
+
+## 1단계: alerter 설치
+
+```bash
+# GitHub 릴리즈에서 다운로드 (Homebrew에는 없음)
+curl -L https://github.com/vjeantet/alerter/releases/download/v26.5/alerter-26.5.zip -o /tmp/alerter.zip
+unzip -o /tmp/alerter.zip -d /tmp/alerter
+
+# PATH에 복사 (sudo 필요)
+sudo cp /tmp/alerter/alerter /usr/local/bin/alerter
+sudo chmod +x /usr/local/bin/alerter
+
+# 설치 확인
+alerter --version
+```
+
+---
+
+## 2단계: Cursor bundle ID 확인
+
+```bash
+mdls -name kMDItemCFBundleIdentifier /Applications/Cursor.app
+# 결과 예시: com.todesktop.230313mzl4w4u92
+```
+
+---
+
+## 3단계: `~/.claude/settings.json` 훅 추가
+
+기존 `settings.json`에 아래 `hooks` 블록을 병합합니다.
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); PROJECT=$(basename \"$PWD\"); TRANSCRIPT=$(echo \"$INPUT\" | jq -r '.transcript_path // \"\"'); CHAT_TITLE=$(grep -o '\"aiTitle\":\"[^\"]*\"' \"$TRANSCRIPT\" 2>/dev/null | tail -1 | sed 's/\"aiTitle\":\"//;s/\"//'); if [ -z \"$CHAT_TITLE\" ]; then CHAT_TITLE=$(echo \"$INPUT\" | jq -r '.last_assistant_message // \"\"' | cut -c1-50); fi; (RESULT=$(alerter --title 'Claude Code ✅ 작업완료' --subtitle \"$PROJECT\" --message \"${CHAT_TITLE:-...}\" --sound 'Glass' --actions '보기' --json --timeout 30 2>/dev/null); echo \"$RESULT\" | grep -q 'actionClicked' && osascript -e 'tell application \"Cursor\" to activate') > /dev/null 2>&1 & disown"
+          }
+        ]
+      }
+    ],
+    "PermissionRequest": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "INPUT=$(cat); PROJECT=$(basename \"$PWD\"); TRANSCRIPT=$(echo \"$INPUT\" | jq -r '.transcript_path // \"\"'); CHAT_TITLE=$(grep -o '\"aiTitle\":\"[^\"]*\"' \"$TRANSCRIPT\" 2>/dev/null | tail -1 | sed 's/\"aiTitle\":\"//;s/\"//'); alerter --title 'Claude Code ⚠️ 확인 필요' --subtitle \"$PROJECT\" --message \"${CHAT_TITLE:-...}\" --sound 'Ping' --timeout 30 > /dev/null 2>&1 & disown"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+---
+
+## 동작 원리
+
+### 채팅 제목 추출 방법
+Claude Code는 세션 파일(`.jsonl`)에 `aiTitle` 필드로 채팅 제목을 저장합니다.
+
+```
+~/.claude/projects/<sanitized-path>/<session_id>.jsonl
+```
+
+훅 stdin으로 `transcript_path`가 전달되므로 이를 직접 사용합니다.
+
+- `aiTitle`이 있으면 → 채팅 제목 사용
+- 없으면(새 대화) → 마지막 응답 앞 50자 사용
+
+### 프로세스 분리
+`& disown`으로 alerter를 완전히 분리해 Claude Code가 훅 완료를 기다리지 않게 합니다.
+`--timeout 0` 대신 `--timeout 30`을 사용해 무한 대기 방지.
+
+### 소리
+`afplay`와 alerter `--sound`를 동시에 쓰면 소리가 2번 납니다. alerter의 `--sound`만 사용합니다.
+
+---
+
+## 트러블슈팅
+
+| 증상 | 원인 | 해결 |
+|------|------|------|
+| 알림이 안 뜸 | `--sender` 옵션으로 타 앱 사칭 시 macOS가 차단 | `--sender` 옵션 제거 |
+| 소리가 2번 남 | `afplay` + `alerter --sound` 중복 | `afplay` 제거 |
+| Claude Code가 계속 실행 중 상태 | `--timeout 0 &`으로 자식 프로세스 미분리 | `& disown` + `--timeout 30` 사용 |
+| 채팅 제목 안 뜸 | 새 대화라 `aiTitle` 미생성 | `last_assistant_message` fallback으로 자동 처리 |

--- a/frontend/cc/api/v3/260623-v3-001-comment.md
+++ b/frontend/cc/api/v3/260623-v3-001-comment.md
@@ -1,0 +1,316 @@
+# COMMENT API (v3)
+
+> Notion [엔드포인트 (3)](https://app.notion.com/p/387b120cfe7180929bc7e3f37001ed71) 기준.
+> **서버구현상태=완료** 항목만 포함. (총 7건)
+> 미포함: 댓글 신고 (시작 전)
+
+| ID | 제목 | 메서드 | URL | 서버 | 클라이언트 | FE검토 |
+| --- | --- | --- | --- | --- | --- | --- |
+| 52 | 댓글 작성 | POST | `api/reply/{planId}` | 완료 | 시작 전 | Y |
+| 53 | 댓글 수정 | PATCH | `api/reply/{replyId}` | 완료 | 시작 전 | Y |
+| 54 | 댓글 삭제 | DELETE | `api/reply/{replyId}` | 완료 | 시작 전 | Y |
+| 55 | 플랜의 댓글 조회 | GET | `api/reply/{planId}?size={}&lastReplyId={}` | 완료 | 시작 전 | Y |
+| 56 | 댓글 좋아요 | POST | `api/reply/like/{replyId}` | 완료 | 시작 전 | Y |
+| 57 | 댓글 좋아요 취소 | DELETE | `api/reply/like/{replyId}` | 완료 | 시작 전 | Y |
+| 59 | 댓글의 대댓글 조회 | GET | `api/reply/{parentReplyId}/children?size={}&lastReplyId={}` | 완료 | 시작 전 | - |
+
+> **v2 대비 변경사항**:
+> - 플랜의 댓글 조회: 서버구현상태 `진행 중` → `완료`, URL에 `size` 파라미터 추가
+> - 댓글의 대댓글 조회: 서버구현상태 `진행 중` → `완료` (신규 완료)
+> - 댓글 신고: 여전히 `시작 전` → 이 파일에서 제외
+
+---
+
+# CMT-52. 댓글 작성
+## URL : POST api/reply/{planId}
+
+**현재 UI 기준 결정 사항**:
+
+- **대댓글 허용 (깊이 1로 제한)**. 대댓글에 다시 대댓글을 다는 행위는 불가하며, 추가 응답이 필요할 경우 본문 내 `@유저` 멘션을 사용해 동일 부모 댓글의 대댓글로 작성한다.
+- **`@유저` 멘션 지원**. 본문에서 `@닉네임` 형태로 다른 사용자를 언급할 수 있으며, 서버는 `mentions` 배열로 멘션 대상 사용자 ID를 함께 받는다.
+- 작성 입력은 textarea 한 개, `maxLength=500`.
+
+### 본문 파라미터
+
+| **이름** | **유형** | **필수/선택** | **설명** |
+| --- | --- | --- | --- |
+| content | String | 필수 | 댓글 본문 내용 (최대 500자). `@닉네임` 형식으로 멘션 표기 가능 |
+| parentReplyId | Integer | 선택 | 대댓글일 경우 부모 댓글 ID. 부모 댓글이 이미 대댓글이면 거절(400) — 깊이 1 제한 |
+| mentions | Array\<Integer\> | 선택 | 본문에서 `@닉네임`으로 언급한 사용자들의 userId 목록 |
+
+### 응답 코드
+
+| status | message |
+| --- | --- |
+| 200 | 성공 |
+| 400 | 요청 데이터 오류 |
+
+## 코드 예시
+
+### 요청 (일반 댓글)
+
+```json
+{
+  "content": "이 코스 따라갔는데 진짜 완벽했어요!"
+}
+```
+
+### 요청 (대댓글 + 멘션)
+
+```json
+{
+  "content": "@여행꿈나무 저도 그 장소 너무 좋았어요! 다음에 같이 가요~",
+  "parentReplyId": 101,
+  "mentions": [12]
+}
+```
+
+### 응답
+
+```json
+{
+  "savedReplyId": 1
+}
+```
+
+---
+
+# CMT-53. 댓글 수정
+## URL : PATCH api/reply/{replyId}
+
+> 현재 메인 UI(`CourseViewPage`)에는 댓글 수정 진입점이 없음. 향후 지원 시 본 명세 사용.
+> 일반 댓글/대댓글 모두 동일 엔드포인트 사용. 부모 관계(`parentReplyId`)는 수정 불가.
+
+### 본문 파라미터
+
+| **이름** | **유형** | **필수/선택** | **설명** |
+| --- | --- | --- | --- |
+| content | String | 필수 | 수정할 댓글 본문 내용 |
+| mentions | Array\<Integer\> | 선택 | 변경된 멘션 대상 userId 목록 |
+
+### 응답 코드
+
+| status | message |
+| --- | --- |
+| 200 | 성공 |
+| 400 | 요청 데이터 오류 |
+
+## 코드 예시
+
+### 요청
+
+```json
+{
+  "content": "@여행꿈나무 수정된 댓글 내용입니다.",
+  "mentions": [12]
+}
+```
+
+### 응답
+
+```json
+{
+  "status": 200
+}
+```
+
+---
+
+# CMT-54. 댓글 삭제
+## URL : DELETE api/reply/{replyId}
+
+### 응답 코드
+
+| status | message |
+| --- | --- |
+| 200 | 성공 |
+| 400 | 요청 데이터 오류 |
+
+## 코드 예시
+
+### 응답
+
+```json
+{
+  "status": 200
+}
+```
+
+---
+
+# CMT-55. 플랜의 댓글 조회
+## URL : GET api/reply/{planId}?size={}&lastReplyId={}
+
+**응답 구조**: 최상위 댓글(부모) 목록을 반환하며, 각 항목에 `replies` 배열로 해당 댓글의 대댓글이 포함된다 (깊이 1 고정). 페이지네이션은 최상위 댓글 기준이며, 대댓글은 부모에 모두 포함되어 함께 반환된다.
+
+### 쿼리 파라미터
+
+| **이름** | **유형** | **필수/선택** | **설명** |
+| --- | --- | --- | --- |
+| lastReplyId | Integer | 필수 | 조회한 가장 마지막 **최상위** 댓글의 replyId (처음 조회면 0) |
+| size | Integer | 선택 | 조회 개수 (기본 20, 현재 UI는 한 번에 전체 노출) |
+
+### 응답 코드
+
+| status | message |
+| --- | --- |
+| 200 | 성공 |
+| 400 | 요청 데이터 오류 (lastReplyId 형식 오류) |
+| 403 | 비공개 플랜의 댓글 접근 권한 없음 |
+| 404 | 대상 플랜을 찾을 수 없음 |
+
+## 코드 예시
+
+### 응답
+
+```json
+{
+  "status": 200,
+  "data": [
+    {
+      "replyId": 101,
+      "parentReplyId": null,
+      "user": "여행꿈나무",
+      "userId": 12,
+      "avatar": "https://i.pravatar.cc/150?u=cm1",
+      "content": "이 코스 따라갔는데 진짜 완벽했어요! 특히 두 번째 장소가 최고 👍",
+      "mentions": [],
+      "createdAt": "2026-05-04T10:23:00Z",
+      "likeCount": 12,
+      "isLiked": false,
+      "replyCount": 2,
+      "replies": [
+        {
+          "replyId": 105,
+          "parentReplyId": 101,
+          "user": "맛집헌터",
+          "userId": 27,
+          "avatar": "https://i.pravatar.cc/150?u=cm2",
+          "content": "@여행꿈나무 저도 그 장소 너무 좋았어요! 다음에 같이 가요~",
+          "mentions": [
+            { "userId": 12, "username": "여행꿈나무" }
+          ],
+          "createdAt": "2026-05-04T11:02:00Z",
+          "likeCount": 3,
+          "isLiked": false
+        },
+        {
+          "replyId": 108,
+          "parentReplyId": 101,
+          "user": "힐링마니아",
+          "userId": 33,
+          "avatar": "https://i.pravatar.cc/150?u=cm3",
+          "content": "@맛집헌터 @여행꿈나무 저도 끼워주세요!",
+          "mentions": [
+            { "userId": 27, "username": "맛집헌터" },
+            { "userId": 12, "username": "여행꿈나무" }
+          ],
+          "createdAt": "2026-05-04T12:15:00Z",
+          "likeCount": 1,
+          "isLiked": false
+        }
+      ]
+    },
+    {
+      "replyId": 102,
+      "parentReplyId": null,
+      "user": "맛집헌터",
+      "userId": 27,
+      "avatar": "https://i.pravatar.cc/150?u=cm2",
+      "content": "주말에 가봤는데 사람이 좀 많았어요. 평일 추천합니다~",
+      "mentions": [],
+      "createdAt": "2026-05-01T18:10:00Z",
+      "likeCount": 8,
+      "isLiked": true,
+      "replyCount": 0,
+      "replies": []
+    }
+  ],
+  "hasNext": false
+}
+```
+
+---
+
+# CMT-56. 댓글 좋아요
+## URL : POST api/reply/like/{replyId}
+
+> `CourseViewPage`의 ThumbsUp 버튼이 비활성 상태일 때 호출. 일반 댓글/대댓글 모두 동일 엔드포인트 사용.
+
+### 응답 코드
+
+| status | message |
+| --- | --- |
+| 200 | 성공 |
+| 400 | 요청 데이터 오류 |
+| 401 | 인증 필요 |
+| 404 | 댓글을 찾을 수 없음 |
+| 409 | 이미 좋아요 처리된 댓글 |
+
+## 코드 예시
+
+### 응답
+
+```json
+{
+  "status": 200,
+  "data": {
+    "replyId": 101,
+    "likeCount": 13,
+    "isLiked": true
+  }
+}
+```
+
+---
+
+# CMT-57. 댓글 좋아요 취소
+## URL : DELETE api/reply/like/{replyId}
+
+> `CourseViewPage`의 ThumbsUp 버튼이 이미 활성 상태일 때 호출. 일반 댓글/대댓글 모두 동일 엔드포인트 사용.
+
+### 응답 코드
+
+| status | message |
+| --- | --- |
+| 200 | 성공 |
+| 400 | 요청 데이터 오류 |
+| 401 | 인증 필요 |
+| 404 | 댓글을 찾을 수 없음 |
+| 409 | 좋아요 상태가 아닌 댓글 |
+
+## 코드 예시
+
+### 응답
+
+```json
+{
+  "status": 200,
+  "data": {
+    "replyId": 101,
+    "likeCount": 12,
+    "isLiked": false
+  }
+}
+```
+
+---
+
+# CMT-59. 댓글의 대댓글 조회
+## URL : GET api/reply/{parentReplyId}/children?size={}&lastReplyId={}
+
+> 특정 부모 댓글의 대댓글 목록을 별도로 조회할 때 사용. 플랜의 댓글 조회(CMT-55)가 대댓글을 포함하여 반환하므로, 추가 로드가 필요한 경우에 사용.
+
+### 쿼리 파라미터
+
+| **이름** | **유형** | **필수/선택** | **설명** |
+| --- | --- | --- | --- |
+| lastReplyId | Integer | - | 마지막으로 조회한 대댓글 ID (처음 조회면 0) |
+| size | Integer | - | 조회 개수 |
+
+### 응답 코드
+
+| status | message |
+| --- | --- |
+| 200 | 성공 |
+| 400 | 요청 데이터 오류 |

--- a/frontend/cc/result/260628-result-010-comment_api_integration.md
+++ b/frontend/cc/result/260628-result-010-comment_api_integration.md
@@ -1,0 +1,42 @@
+# 댓글 API 연동 구현 결과 (v3 CMT-52~57, 59)
+
+> 기준 명세: `cc/api/v3/260623-v3-001-comment.md`
+
+## 생성/수정 파일
+
+| 파일 | 상태 | 설명 |
+|------|------|------|
+| `src/features/course-detail/types/comment.types.ts` | 신규 | API 응답 타입 (ParentReplyItem, ReplyItem 등) |
+| `src/features/course-detail/api/comment.api.ts` | 신규 | 댓글 API 함수 6종 |
+| `src/features/course-detail/hooks/useComments.ts` | 신규 | 댓글 상태 관리 훅 |
+| `src/features/course-detail/components/CourseViewPage.tsx` | 수정 | mock → 실 API 연결 |
+
+## 구현 내용
+
+### API 함수 (`comment.api.ts`)
+- `fetchComments(planId, lastReplyId, size?)` — CMT-55 커서 페이지네이션
+- `postComment(planId, body)` — CMT-52 댓글/대댓글 작성 (parentReplyId 포함)
+- `deleteComment(replyId)` — CMT-54
+- `likeComment(replyId)` — CMT-56
+- `unlikeComment(replyId)` — CMT-57
+- `fetchChildReplies(parentReplyId, lastReplyId, size?)` — CMT-59 (추가 로드용, 현재 미사용)
+
+### useComments 훅
+- 초기 로드 (`loadComments`) + 커서 기반 더보기 (`fetchMore`)
+- 답글 모드: `replyTarget` 상태로 parentReplyId 전달
+- 낙관적 업데이트 없이 서버 응답 기반 상태 갱신 (delete/like)
+- `toggleCommentLike` — 부모/대댓글 모두 처리 (parentId 파라미터로 구분)
+- `hideComment(id)` — 신고 후 즉시 숨기기 지원
+
+### CourseViewPage 변경
+- `MOCK_COMMENTS` 제거, `useComments(courseId)` 훅으로 교체
+- 댓글 로딩 스켈레톤 추가
+- 부모 댓글 아래 대댓글 인덴트 표시 (`replies[]`)
+- 답글 모드 UI: 타겟 배너 + textarea placeholder 변경
+- "댓글 더 보기" 버튼 (`hasNext` 기반)
+- 삭제 확인 모달: `Comment` → `DeleteTarget` 타입으로 교체
+
+## 미구현 (명세 범위 외)
+- CMT-53 댓글 수정 (현재 UI에 진입점 없음 — 명세 주석과 동일)
+- 대댓글 추가 로드 (CMT-59): fetchChildReplies 함수는 준비됨, UI 트리거 미구현
+- `@멘션` 자동완성 UI

--- a/frontend/src/features/course-detail/api/comment.api.ts
+++ b/frontend/src/features/course-detail/api/comment.api.ts
@@ -1,0 +1,54 @@
+import apiClient from '@/shared/lib/api/apiClient';
+import type {
+  GetRepliesResponse,
+  PostCommentBody,
+  PostCommentResponse,
+  LikeCommentResponse,
+} from '../types/comment.types';
+
+export async function fetchComments(
+  planId: string,
+  lastReplyId = 0,
+  size?: number
+): Promise<GetRepliesResponse> {
+  const params: Record<string, string | number> = { lastReplyId };
+  if (size !== undefined) params.size = size;
+  const { data } = await apiClient.get<GetRepliesResponse>(`/api/reply/${planId}`, { params });
+  return data;
+}
+
+export async function postComment(
+  planId: string,
+  body: PostCommentBody
+): Promise<PostCommentResponse> {
+  const { data } = await apiClient.post<PostCommentResponse>(`/api/reply/${planId}`, body);
+  return data;
+}
+
+export async function deleteComment(replyId: number): Promise<void> {
+  await apiClient.delete(`/api/reply/${replyId}`);
+}
+
+export async function likeComment(replyId: number): Promise<LikeCommentResponse> {
+  const { data } = await apiClient.post<LikeCommentResponse>(`/api/reply/like/${replyId}`);
+  return data;
+}
+
+export async function unlikeComment(replyId: number): Promise<LikeCommentResponse> {
+  const { data } = await apiClient.delete<LikeCommentResponse>(`/api/reply/like/${replyId}`);
+  return data;
+}
+
+export async function fetchChildReplies(
+  parentReplyId: number,
+  lastReplyId = 0,
+  size?: number
+): Promise<GetRepliesResponse> {
+  const params: Record<string, string | number> = { lastReplyId };
+  if (size !== undefined) params.size = size;
+  const { data } = await apiClient.get<GetRepliesResponse>(
+    `/api/reply/${parentReplyId}/children`,
+    { params }
+  );
+  return data;
+}

--- a/frontend/src/features/course-detail/components/CourseViewPage.tsx
+++ b/frontend/src/features/course-detail/components/CourseViewPage.tsx
@@ -16,18 +16,19 @@ import {
   MoreVertical,
   Trash2,
   X,
+  Plus,
 } from 'lucide-react';
 import { motion } from 'motion/react';
 import { toast } from 'sonner';
 import { useCourseStore } from '@/shared/lib/stores/useCourseStore';
 import { useUserStore } from '@/shared/lib/stores/useUserStore';
 import { ShareBottomSheet } from '@/shared/ui/ShareBottomSheet';
+import { BottomActionBar } from '@/shared/ui/BottomActionBar';
 import { CourseDetailSkeleton } from '@/shared/ui/Skeleton';
-import { MOCK_COMMENTS } from '@/shared/data/mockData';
 import { useReport, ReportDialog, ReportMenuItem } from '@/features/report';
 import * as hiddenReportsStorage from '@/features/report/utils/hiddenReportsStorage';
 import type { CurrentUser, ReportTarget } from '@/features/report';
-import type { Comment } from '@/shared/types';
+import { useComments } from '../hooks/useComments';
 
 interface CourseViewPageProps {
   courseId: string;
@@ -63,14 +64,28 @@ export function CourseViewPage({ courseId }: CourseViewPageProps) {
   const reportMenuTriggerRef = useRef<HTMLButtonElement>(null);
   const reportCtx = useReport({ reporterId: currentUser.id });
 
+  const {
+    comments,
+    isLoading: isCommentsLoading,
+    hasNext,
+    isFetchingMore,
+    commentText,
+    setCommentText,
+    replyTarget,
+    setReplyTarget,
+    deleteTarget,
+    setDeleteTarget,
+    submitComment,
+    confirmDelete,
+    toggleCommentLike,
+    hideComment,
+    fetchMore,
+  } = useComments(courseId);
+
   const [shareOpen, setShareOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [showSaveModal, setShowSaveModal] = useState(false);
   const [savedCourseId, setSavedCourseId] = useState<string | null>(null);
-  const [commentText, setCommentText] = useState('');
-  const [comments, setComments] = useState<Comment[]>(MOCK_COMMENTS);
-  const [likedComments, setLikedComments] = useState<Set<string>>(new Set());
-  const [commentToDelete, setCommentToDelete] = useState<Comment | null>(null);
   // 어느 댓글의 메뉴인지 추적 — race condition 차단 (Architect C-3)
   const [commentMenuTarget, setCommentMenuTarget] = useState<ReportTarget | null>(null);
 
@@ -120,43 +135,6 @@ export function CourseViewPage({ courseId }: CourseViewPageProps) {
     }
     setShowSaveModal(false);
     setSavedCourseId(null);
-  };
-
-  const handleCommentSubmit = () => {
-    if (!commentText.trim()) return;
-    const newComment: Comment = {
-      id: Date.now().toString(),
-      user: '김여행',
-      avatar: 'https://i.pravatar.cc/150?u=me',
-      text: commentText,
-      date: '방금',
-      likes: 0,
-    };
-    setComments([newComment, ...comments]);
-    setCommentText('');
-    toast.success('댓글이 등록되었어요!');
-  };
-
-  const handleLikeComment = (commentId: string) => {
-    setLikedComments((prev) => {
-      const next = new Set(prev);
-      if (next.has(commentId)) next.delete(commentId);
-      else next.add(commentId);
-      return next;
-    });
-  };
-
-  const confirmDeleteComment = () => {
-    if (!commentToDelete) return;
-    setComments((prev) => prev.filter((c) => c.id !== commentToDelete.id));
-    setLikedComments((prev) => {
-      if (!prev.has(commentToDelete.id)) return prev;
-      const next = new Set(prev);
-      next.delete(commentToDelete.id);
-      return next;
-    });
-    setCommentToDelete(null);
-    toast.success('댓글이 삭제되었어요.');
   };
 
   // 관련 플랜 — 태그 매칭 또는 같은 지역 기반 필터링
@@ -324,78 +302,184 @@ export function CourseViewPage({ courseId }: CourseViewPageProps) {
           <MessageCircle size={20} className="text-sky-500" /> 댓글
         </h2>
         <div className="mb-4">
+          {replyTarget && (
+            <div className="flex items-center justify-between bg-sky-50 border border-sky-200 rounded-lg px-3 py-2 mb-2 text-sm text-sky-700">
+              <span><span className="font-bold">@{replyTarget.username}</span>에게 답글</span>
+              <button onClick={() => setReplyTarget(null)} aria-label="답글 취소">
+                <X size={14} />
+              </button>
+            </div>
+          )}
           <textarea
             value={commentText}
             onChange={(e) => setCommentText(e.target.value)}
-            placeholder="댓글을 입력하세요..."
+            placeholder={replyTarget ? `@${replyTarget.username}에게 답글...` : '댓글을 입력하세요...'}
             className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:border-sky-500 text-base"
             rows={2}
             maxLength={500}
           />
           <button
-            onClick={handleCommentSubmit}
+            onClick={submitComment}
             className="mt-2 w-full bg-sky-500 text-white font-bold py-3 rounded-xl shadow-lg shadow-sky-200 active:scale-[0.98] transition-transform"
           >
-            댓글 작성
+            {replyTarget ? '답글 작성' : '댓글 작성'}
           </button>
         </div>
-        <div className="space-y-4">
-          {comments.map((comment) => (
-            <div key={comment.id} className="flex items-start gap-3">
-              <div className="relative w-9 h-9 rounded-full overflow-hidden flex-shrink-0">
-                <Image src={comment.avatar} alt="Avatar" fill sizes="36px" className="object-cover" />
-              </div>
-              <div className="flex-1">
-                <div className="flex items-center justify-between">
-                  <div className="text-sm font-bold text-gray-900">{comment.user}</div>
-                  <div className="text-xs text-gray-500">{comment.date}</div>
-                </div>
-                <p className="text-sm text-gray-500 bg-gray-50 p-3 rounded-lg border border-gray-100 mt-1">
-                  {comment.text}
-                </p>
-                <div className="flex items-center gap-2 mt-1">
-                  <button
-                    onClick={() => handleLikeComment(comment.id)}
-                    className={`text-sm ${likedComments.has(comment.id) ? 'text-red-500' : 'text-gray-500'}`}
-                  >
-                    <ThumbsUp size={16} />
-                  </button>
-                  <span className="text-sm text-gray-500">
-                    {likedComments.has(comment.id) ? comment.likes + 1 : comment.likes}
-                  </span>
-                  {comment.user === currentUser.name ? (
-                    // 본인 댓글: 삭제 버튼 유지
-                    <button
-                      onClick={() => setCommentToDelete(comment)}
-                      aria-label="댓글 삭제"
-                      className="ml-auto text-gray-400 hover:text-red-500 active:text-red-600"
-                    >
-                      <Trash2 size={16} />
-                    </button>
-                  ) : (
-                    // 타인 댓글: 신고 진입점 ⋮ 버튼 (Q6: BottomMenu 단일 트리거)
-                    <button
-                      onClick={() =>
-                        setCommentMenuTarget({
-                          type: 'comment',
-                          id: comment.id,
-                          ownerId: comment.user,
-                          courseId,
-                          snippet: comment.text.slice(0, 60),
-                          contextUrl: `/course/${courseId}#comment-${comment.id}`,
-                        })
-                      }
-                      aria-label="댓글 더보기"
-                      className="ml-auto text-gray-400 hover:text-gray-600 active:text-gray-700"
-                    >
-                      <MoreVertical size={16} />
-                    </button>
-                  )}
+        {isCommentsLoading ? (
+          <div className="space-y-4">
+            {[1, 2, 3].map((i) => (
+              <div key={i} className="flex items-start gap-3 animate-pulse">
+                <div className="w-9 h-9 rounded-full bg-gray-200 flex-shrink-0" />
+                <div className="flex-1 space-y-2">
+                  <div className="h-3 bg-gray-200 rounded w-24" />
+                  <div className="h-10 bg-gray-100 rounded-lg" />
                 </div>
               </div>
-            </div>
-          ))}
-        </div>
+            ))}
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {comments.map((comment) => (
+              <div key={comment.replyId}>
+                {/* 부모 댓글 */}
+                <div className="flex items-start gap-3">
+                  <div className="relative w-9 h-9 rounded-full overflow-hidden flex-shrink-0">
+                    <Image src={comment.avatar} alt="Avatar" fill sizes="36px" className="object-cover" />
+                  </div>
+                  <div className="flex-1">
+                    <div className="flex items-center justify-between">
+                      <div className="text-sm font-bold text-gray-900">{comment.user}</div>
+                      <div className="text-xs text-gray-500">
+                        {new Date(comment.createdAt).toLocaleDateString('ko-KR')}
+                      </div>
+                    </div>
+                    <p className="text-sm text-gray-600 bg-gray-50 p-3 rounded-lg border border-gray-100 mt-1 whitespace-pre-wrap">
+                      {comment.content}
+                    </p>
+                    <div className="flex items-center gap-3 mt-1.5">
+                      <button
+                        onClick={() => toggleCommentLike(comment.replyId, comment.isLiked, null)}
+                        className={`flex items-center gap-1 text-sm ${comment.isLiked ? 'text-sky-500' : 'text-gray-400'}`}
+                      >
+                        <ThumbsUp size={14} />
+                        <span>{comment.likeCount}</span>
+                      </button>
+                      <button
+                        onClick={() => setReplyTarget({ replyId: comment.replyId, username: comment.user })}
+                        className="text-xs text-gray-400 hover:text-sky-500"
+                      >
+                        답글
+                      </button>
+                      {comment.user === currentUser.name ? (
+                        <button
+                          onClick={() =>
+                            setDeleteTarget({ replyId: comment.replyId, content: comment.content, parentId: null })
+                          }
+                          aria-label="댓글 삭제"
+                          className="ml-auto text-gray-400 hover:text-red-500"
+                        >
+                          <Trash2 size={14} />
+                        </button>
+                      ) : (
+                        <button
+                          onClick={() =>
+                            setCommentMenuTarget({
+                              type: 'comment',
+                              id: String(comment.replyId),
+                              ownerId: comment.user,
+                              courseId,
+                              snippet: comment.content.slice(0, 60),
+                              contextUrl: `/course/${courseId}#comment-${comment.replyId}`,
+                            })
+                          }
+                          aria-label="댓글 더보기"
+                          className="ml-auto text-gray-400 hover:text-gray-600"
+                        >
+                          <MoreVertical size={14} />
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                </div>
+
+                {/* 대댓글 */}
+                {comment.replies.length > 0 && (
+                  <div className="ml-12 mt-3 space-y-3 border-l-2 border-gray-100 pl-3">
+                    {comment.replies.map((reply) => (
+                      <div key={reply.replyId} className="flex items-start gap-3">
+                        <div className="relative w-7 h-7 rounded-full overflow-hidden flex-shrink-0">
+                          <Image src={reply.avatar} alt="Avatar" fill sizes="28px" className="object-cover" />
+                        </div>
+                        <div className="flex-1">
+                          <div className="flex items-center justify-between">
+                            <div className="text-xs font-bold text-gray-900">{reply.user}</div>
+                            <div className="text-[10px] text-gray-400">
+                              {new Date(reply.createdAt).toLocaleDateString('ko-KR')}
+                            </div>
+                          </div>
+                          <p className="text-xs text-gray-600 bg-gray-50 p-2.5 rounded-lg border border-gray-100 mt-1 whitespace-pre-wrap">
+                            {reply.content}
+                          </p>
+                          <div className="flex items-center gap-3 mt-1">
+                            <button
+                              onClick={() => toggleCommentLike(reply.replyId, reply.isLiked, comment.replyId)}
+                              className={`flex items-center gap-1 text-xs ${reply.isLiked ? 'text-sky-500' : 'text-gray-400'}`}
+                            >
+                              <ThumbsUp size={12} />
+                              <span>{reply.likeCount}</span>
+                            </button>
+                            {reply.user === currentUser.name ? (
+                              <button
+                                onClick={() =>
+                                  setDeleteTarget({
+                                    replyId: reply.replyId,
+                                    content: reply.content,
+                                    parentId: comment.replyId,
+                                  })
+                                }
+                                aria-label="답글 삭제"
+                                className="ml-auto text-gray-400 hover:text-red-500"
+                              >
+                                <Trash2 size={12} />
+                              </button>
+                            ) : (
+                              <button
+                                onClick={() =>
+                                  setCommentMenuTarget({
+                                    type: 'comment',
+                                    id: String(reply.replyId),
+                                    ownerId: reply.user,
+                                    courseId,
+                                    snippet: reply.content.slice(0, 60),
+                                    contextUrl: `/course/${courseId}#comment-${reply.replyId}`,
+                                  })
+                                }
+                                aria-label="답글 더보기"
+                                className="ml-auto text-gray-400 hover:text-gray-600"
+                              >
+                                <MoreVertical size={12} />
+                              </button>
+                            )}
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+
+            {hasNext && (
+              <button
+                onClick={fetchMore}
+                disabled={isFetchingMore}
+                className="w-full py-2.5 text-sm text-sky-600 font-medium border border-sky-200 rounded-xl hover:bg-sky-50 disabled:opacity-50"
+              >
+                {isFetchingMore ? '불러오는 중...' : '댓글 더 보기'}
+              </button>
+            )}
+          </div>
+        )}
       </div>
 
       {/* 관련 플랜 */}
@@ -433,41 +517,37 @@ export function CourseViewPage({ courseId }: CourseViewPageProps) {
         </div>
       )}
 
-      {/* Sticky 하단 FAB */}
-      <div className="fixed bottom-0 left-0 right-0 p-4 bg-white border-t border-gray-100 flex gap-2 justify-center max-w-[480px] mx-auto z-50">
-        <motion.button
-          whileTap={{ scale: 0.95 }}
-          onClick={() => {
-            toggleLike(courseId);
-            toast(liked ? '좋아요를 취소했어요.' : '좋아요를 눌렀어요!');
-          }}
-          className={`p-3.5 rounded-xl border transition-colors ${
-            liked ? 'bg-red-50 border-red-200 text-red-500' : 'bg-gray-50 border-gray-200 text-gray-400'
-          }`}
-        >
-          <Heart size={22} className={liked ? 'fill-red-500' : ''} />
-        </motion.button>
-        <motion.button
-          whileTap={{ scale: 0.95 }}
-          onClick={() => {
-            toggleBookmark(courseId);
-            toast.success(bookmarked ? '저장을 해제했어요.' : '플랜을 저장했어요!');
-          }}
-          className={`p-3.5 rounded-xl border transition-colors ${
-            bookmarked
-              ? 'bg-amber-50 border-amber-200 text-amber-500'
-              : 'bg-gray-50 border-gray-200 text-gray-400'
-          }`}
-        >
-          <Bookmark size={22} className={bookmarked ? 'fill-amber-500' : ''} />
-        </motion.button>
-        <button
-          onClick={handleSaveCourse}
-          className="flex-1 bg-sky-500 text-white font-bold py-3.5 rounded-xl shadow-lg shadow-sky-200 active:scale-[0.98] transition-transform"
-        >
-          이 플랜으로 일정 담기
-        </button>
-      </div>
+      <BottomActionBar
+        iconActions={[
+          {
+            id: 'like',
+            icon: Heart,
+            label: '좋아요',
+            active: liked,
+            activeTone: 'like',
+            filled: true,
+            onClick: () => {
+              toggleLike(courseId);
+              toast(liked ? '좋아요를 취소했어요.' : '좋아요를 눌렀어요!');
+            },
+          },
+          {
+            id: 'bookmark',
+            icon: Bookmark,
+            label: '스크랩',
+            active: bookmarked,
+            activeTone: 'bookmark',
+            filled: true,
+            onClick: () => {
+              toggleBookmark(courseId);
+              toast.success(bookmarked ? '저장을 해제했어요.' : '플랜을 저장했어요!');
+            },
+          },
+        ]}
+        primaryLabel="이 플랜으로 일정 담기"
+        primaryIcon={Plus}
+        onPrimaryClick={handleSaveCourse}
+      />
 
       {/* ─── 모달: 일정 담기 ─── */}
       {showSaveModal && (
@@ -579,7 +659,7 @@ export function CourseViewPage({ courseId }: CourseViewPageProps) {
         onHideContent={(t) => {
           if (t.type === 'comment') {
             // 댓글 신고 후 숨기기: 해당 댓글만 페이지에서 즉시 제거 + 로컬 스토리지에도 기록
-            setComments((prev) => prev.filter((c) => c.id !== t.id));
+            hideComment(t.id);
             hiddenReportsStorage.add(t);
           } else {
             // 플랜 신고 후 숨기기: 로컬 스토리지 기록 + 페이지 이탈
@@ -620,33 +700,33 @@ export function CourseViewPage({ courseId }: CourseViewPageProps) {
       )}
 
       {/* ─── 댓글 삭제 확인 모달 ─── */}
-      {commentToDelete && (
+      {deleteTarget && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-          <div className="absolute inset-0 bg-black/50" onClick={() => setCommentToDelete(null)} />
+          <div className="absolute inset-0 bg-black/50" onClick={() => setDeleteTarget(null)} />
           <div className="relative w-full max-w-[320px] bg-white rounded-2xl p-6 shadow-lg">
             <h3 className="text-gray-900 text-lg font-bold mb-2">댓글을 삭제하시겠어요?</h3>
             <p className="text-gray-500 text-sm mb-4 leading-relaxed">
               삭제된 댓글은 복구할 수 없습니다.
             </p>
             <p className="text-sm text-gray-700 bg-gray-50 p-3 rounded-lg border border-gray-100 mb-5 line-clamp-3">
-              {commentToDelete.text}
+              {deleteTarget.content}
             </p>
             <div className="flex gap-3">
               <button
-                onClick={() => setCommentToDelete(null)}
+                onClick={() => setDeleteTarget(null)}
                 className="flex-1 bg-gray-100 text-gray-700 font-bold py-2.5 px-4 rounded-xl text-sm hover:bg-gray-200"
               >
                 취소
               </button>
               <button
-                onClick={confirmDeleteComment}
+                onClick={confirmDelete}
                 className="flex-1 bg-red-500 text-white font-bold py-2.5 px-4 rounded-xl text-sm shadow-md shadow-red-200 hover:bg-red-600"
               >
                 삭제하기
               </button>
             </div>
             <button
-              onClick={() => setCommentToDelete(null)}
+              onClick={() => setDeleteTarget(null)}
               aria-label="닫기"
               className="absolute top-3 right-3 text-gray-400 hover:text-gray-600"
             >

--- a/frontend/src/features/course-detail/hooks/useComments.ts
+++ b/frontend/src/features/course-detail/hooks/useComments.ts
@@ -1,0 +1,140 @@
+import { useState, useCallback, useEffect } from 'react';
+import { toast } from 'sonner';
+import * as commentApi from '../api/comment.api';
+import type { ParentReplyItem, DeleteTarget } from '../types/comment.types';
+
+export function useComments(planId: string) {
+  const [comments, setComments] = useState<ParentReplyItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasNext, setHasNext] = useState(false);
+  const [isFetchingMore, setIsFetchingMore] = useState(false);
+  const [commentText, setCommentText] = useState('');
+  const [replyTarget, setReplyTarget] = useState<{ replyId: number; username: string } | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<DeleteTarget | null>(null);
+
+  const loadComments = useCallback(
+    async (lastReplyId = 0, append = false) => {
+      try {
+        if (append) setIsFetchingMore(true);
+        else setIsLoading(true);
+        const res = await commentApi.fetchComments(planId, lastReplyId);
+        setComments((prev) => (append ? [...prev, ...res.data] : res.data));
+        setHasNext(res.hasNext);
+      } catch {
+        toast.error('댓글을 불러오지 못했어요.');
+      } finally {
+        setIsLoading(false);
+        setIsFetchingMore(false);
+      }
+    },
+    [planId]
+  );
+
+  useEffect(() => {
+    loadComments();
+  }, [loadComments]);
+
+  const fetchMore = useCallback(() => {
+    if (!comments.length || isFetchingMore || !hasNext) return;
+    const lastId = comments[comments.length - 1].replyId;
+    loadComments(lastId, true);
+  }, [comments, isFetchingMore, hasNext, loadComments]);
+
+  const submitComment = useCallback(async () => {
+    const content = commentText.trim();
+    if (!content) return;
+    try {
+      const body = replyTarget
+        ? { content, parentReplyId: replyTarget.replyId }
+        : { content };
+      await commentApi.postComment(planId, body);
+      setCommentText('');
+      setReplyTarget(null);
+      await loadComments();
+      toast.success(replyTarget ? '답글이 등록되었어요!' : '댓글이 등록되었어요!');
+    } catch {
+      toast.error('댓글 작성에 실패했어요.');
+    }
+  }, [commentText, planId, replyTarget, loadComments]);
+
+  const confirmDelete = useCallback(async () => {
+    if (!deleteTarget) return;
+    try {
+      await commentApi.deleteComment(deleteTarget.replyId);
+      if (deleteTarget.parentId === null) {
+        setComments((prev) => prev.filter((c) => c.replyId !== deleteTarget.replyId));
+      } else {
+        setComments((prev) =>
+          prev.map((c) =>
+            c.replyId === deleteTarget.parentId
+              ? {
+                  ...c,
+                  replies: c.replies.filter((r) => r.replyId !== deleteTarget.replyId),
+                  replyCount: c.replyCount - 1,
+                }
+              : c
+          )
+        );
+      }
+      setDeleteTarget(null);
+      toast.success('댓글이 삭제되었어요.');
+    } catch {
+      toast.error('댓글 삭제에 실패했어요.');
+    }
+  }, [deleteTarget]);
+
+  const toggleLike = useCallback(
+    async (replyId: number, isLiked: boolean, parentId: number | null) => {
+      try {
+        const res = isLiked
+          ? await commentApi.unlikeComment(replyId)
+          : await commentApi.likeComment(replyId);
+        const { likeCount, isLiked: newIsLiked } = res.data;
+
+        if (parentId === null) {
+          setComments((prev) =>
+            prev.map((c) => (c.replyId === replyId ? { ...c, likeCount, isLiked: newIsLiked } : c))
+          );
+        } else {
+          setComments((prev) =>
+            prev.map((c) =>
+              c.replyId === parentId
+                ? {
+                    ...c,
+                    replies: c.replies.map((r) =>
+                      r.replyId === replyId ? { ...r, likeCount, isLiked: newIsLiked } : r
+                    ),
+                  }
+                : c
+            )
+          );
+        }
+      } catch {
+        toast.error('좋아요 처리에 실패했어요.');
+      }
+    },
+    []
+  );
+
+  const hideComment = useCallback((replyId: string) => {
+    setComments((prev) => prev.filter((c) => String(c.replyId) !== replyId));
+  }, []);
+
+  return {
+    comments,
+    isLoading,
+    hasNext,
+    isFetchingMore,
+    commentText,
+    setCommentText,
+    replyTarget,
+    setReplyTarget,
+    deleteTarget,
+    setDeleteTarget,
+    submitComment,
+    confirmDelete,
+    toggleCommentLike: toggleLike,
+    hideComment,
+    fetchMore,
+  };
+}

--- a/frontend/src/features/course-detail/types/comment.types.ts
+++ b/frontend/src/features/course-detail/types/comment.types.ts
@@ -1,0 +1,53 @@
+export interface ReplyMention {
+  userId: number;
+  username: string;
+}
+
+export interface ReplyItem {
+  replyId: number;
+  parentReplyId: number | null;
+  user: string;
+  userId: number;
+  avatar: string;
+  content: string;
+  mentions: ReplyMention[];
+  createdAt: string;
+  likeCount: number;
+  isLiked: boolean;
+}
+
+export interface ParentReplyItem extends ReplyItem {
+  replyCount: number;
+  replies: ReplyItem[];
+}
+
+export interface GetRepliesResponse {
+  status: 200;
+  data: ParentReplyItem[];
+  hasNext: boolean;
+}
+
+export interface PostCommentBody {
+  content: string;
+  parentReplyId?: number;
+  mentions?: number[];
+}
+
+export interface PostCommentResponse {
+  savedReplyId: number;
+}
+
+export interface LikeCommentResponse {
+  status: 200;
+  data: {
+    replyId: number;
+    likeCount: number;
+    isLiked: boolean;
+  };
+}
+
+export interface DeleteTarget {
+  replyId: number;
+  content: string;
+  parentId: number | null;
+}

--- a/frontend/src/features/place-detail/components/PlaceDetailPage.tsx
+++ b/frontend/src/features/place-detail/components/PlaceDetailPage.tsx
@@ -21,6 +21,7 @@ import { motion } from 'motion/react';
 import { toast } from 'sonner';
 import { useCourseStore } from '@/shared/lib/stores/useCourseStore';
 import { ShareBottomSheet } from '@/shared/ui/ShareBottomSheet';
+import { BottomActionBar } from '@/shared/ui/BottomActionBar';
 import { PlaceAddSheet } from '@/shared/ui/PlaceAddSheet';
 import { ScrollCarousel } from '@/shared/ui/ScrollCarousel';
 import {
@@ -403,26 +404,31 @@ export function PlaceDetailPage({ placeId }: PlaceDetailPageProps) {
         </div>
       )}
 
-      {/* Sticky 하단 CTA */}
-      <div className="fixed bottom-0 left-0 right-0 z-20">
-        <div className="max-w-[480px] mx-auto bg-white border-t border-gray-100 px-5 py-3 flex gap-3">
-          <button
-            onClick={handleLike}
-            className={`px-4 py-3 rounded-xl border transition-all active:scale-95 ${
-              isLiked ? 'border-red-200 bg-red-50 text-red-500' : 'border-gray-200 bg-white text-gray-500'
-            }`}
-          >
-            <Heart size={20} className={isLiked ? 'fill-red-500' : ''} />
-          </button>
-          <button
-            onClick={() => setIsAddSheetOpen(true)}
-            className="flex-1 flex items-center justify-center gap-2 bg-sky-500 text-white font-bold py-3 rounded-xl shadow-lg shadow-sky-200 active:scale-[0.98] transition-transform"
-          >
-            <Plus size={18} strokeWidth={3} />
-            내 플랜에 담기
-          </button>
-        </div>
-      </div>
+      <BottomActionBar
+        iconActions={[
+          {
+            id: 'like',
+            icon: Heart,
+            label: '좋아요',
+            active: isLiked,
+            activeTone: 'like',
+            filled: true,
+            onClick: handleLike,
+          },
+          {
+            id: 'bookmark',
+            icon: Bookmark,
+            label: '스크랩',
+            active: bookmarked,
+            activeTone: 'bookmark',
+            filled: true,
+            onClick: handleBookmark,
+          },
+        ]}
+        primaryLabel="내 플랜에 담기"
+        primaryIcon={Plus}
+        onPrimaryClick={() => setIsAddSheetOpen(true)}
+      />
 
       <PlaceAddSheet
         open={isAddSheetOpen}

--- a/frontend/src/shared/ui/BottomActionBar/component.tsx
+++ b/frontend/src/shared/ui/BottomActionBar/component.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import React from 'react';
+import type { BottomActionBarActiveTone, BottomActionBarProps } from './types';
+import styles from './styles.module.scss';
+
+function getActiveClassName(tone: BottomActionBarActiveTone = 'default') {
+  switch (tone) {
+    case 'like':
+      return styles.iconButtonActiveLike;
+    case 'bookmark':
+      return styles.iconButtonActiveBookmark;
+    default:
+      return styles.iconButtonActiveDefault;
+  }
+}
+
+const BottomActionBar: React.FC<BottomActionBarProps> = ({
+  iconActions,
+  primaryLabel,
+  primaryIcon: PrimaryIcon,
+  onPrimaryClick,
+  className = '',
+}) => {
+  return (
+    <div className={`${styles.bar} ${className}`} role="toolbar" aria-label="하단 액션">
+      <div className={styles.pill}>
+        {iconActions.map(
+          ({ id, icon: Icon, label, active, activeTone, filled, onClick }) => (
+            <button
+              key={id}
+              type="button"
+              className={`${styles.iconButton} ${active ? getActiveClassName(activeTone) : ''}`}
+              aria-label={label}
+              aria-pressed={active}
+              onClick={onClick}
+            >
+              <Icon aria-hidden="true" size={20} className={active && filled ? 'fill-current' : ''} />
+              <span className={styles.iconLabel}>{label}</span>
+            </button>
+          )
+        )}
+        <button type="button" className={styles.primaryButton} onClick={onPrimaryClick}>
+          {PrimaryIcon && <PrimaryIcon aria-hidden="true" size={18} strokeWidth={3} />}
+          <span className={styles.primaryLabel}>{primaryLabel}</span>
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default BottomActionBar;

--- a/frontend/src/shared/ui/BottomActionBar/index.ts
+++ b/frontend/src/shared/ui/BottomActionBar/index.ts
@@ -1,0 +1,6 @@
+export { default as BottomActionBar } from './component';
+export type {
+  BottomActionBarActiveTone,
+  BottomActionBarIconAction,
+  BottomActionBarProps,
+} from './types';

--- a/frontend/src/shared/ui/BottomActionBar/styles.module.scss
+++ b/frontend/src/shared/ui/BottomActionBar/styles.module.scss
@@ -1,0 +1,122 @@
+.bar {
+  position: fixed;
+  bottom: calc(12px + env(safe-area-inset-bottom, 0px));
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 100;
+  pointer-events: none;
+  width: min(390px, calc(100% - 40px));
+}
+
+.pill {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  box-shadow:
+    0 4px 24px rgba(0, 0, 0, 0.12),
+    0 1px 4px rgba(0, 0, 0, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  pointer-events: auto;
+}
+
+.iconButton {
+  width: 52px;
+  height: 52px;
+  flex-shrink: 0;
+  border-radius: 9999px;
+  border: 1.5px solid transparent;
+  background: transparent;
+  color: rgba(80, 80, 90, 0.75);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 2px;
+  transition: all 0.2s ease;
+  cursor: pointer;
+
+  &:hover {
+    background: rgba(255, 255, 255, 0.45);
+    color: #0ea5e9;
+  }
+
+  &:active {
+    transform: scale(0.92);
+  }
+}
+
+.iconLabel {
+  font-size: 9px;
+  font-weight: 500;
+  line-height: 1;
+}
+
+.iconButtonActiveDefault {
+  color: #0ea5e9;
+  background: rgba(255, 255, 255, 0.45);
+}
+
+.iconButtonActiveLike {
+  color: #ef4444;
+  background: rgba(254, 226, 226, 0.65);
+
+  &:hover {
+    color: #ef4444;
+    background: rgba(254, 226, 226, 0.8);
+  }
+}
+
+.iconButtonActiveBookmark {
+  color: #f59e0b;
+  background: rgba(254, 243, 199, 0.65);
+
+  &:hover {
+    color: #f59e0b;
+    background: rgba(254, 243, 199, 0.8);
+  }
+}
+
+.primaryButton {
+  flex: 1;
+  min-width: 0;
+  height: 52px;
+  border: none;
+  border-radius: 9999px;
+  background: #0ea5e9;
+  color: #ffffff;
+  font-size: 14px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 0 16px;
+  cursor: pointer;
+  box-shadow: 0 4px 14px rgba(14, 165, 233, 0.35);
+  transition: all 0.2s ease;
+
+  &:hover {
+    background: #38bdf8;
+    box-shadow:
+      0 6px 18px rgba(56, 189, 248, 0.45),
+      inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+}
+
+.primaryLabel {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}

--- a/frontend/src/shared/ui/BottomActionBar/types.ts
+++ b/frontend/src/shared/ui/BottomActionBar/types.ts
@@ -1,0 +1,21 @@
+import type { LucideIcon } from 'lucide-react';
+
+export type BottomActionBarActiveTone = 'default' | 'like' | 'bookmark';
+
+export interface BottomActionBarIconAction {
+  id: string;
+  icon: LucideIcon;
+  label: string;
+  active?: boolean;
+  activeTone?: BottomActionBarActiveTone;
+  filled?: boolean;
+  onClick: () => void;
+}
+
+export interface BottomActionBarProps {
+  iconActions: BottomActionBarIconAction[];
+  primaryLabel: string;
+  primaryIcon?: LucideIcon;
+  onPrimaryClick: () => void;
+  className?: string;
+}

--- a/frontend/src/shared/ui/BottomNavigation/styles.module.scss
+++ b/frontend/src/shared/ui/BottomNavigation/styles.module.scss
@@ -1,32 +1,36 @@
 .bottomNavigation {
-  width: min(390px, 100%);
   position: fixed;
-  bottom: 0;
+  bottom: calc(12px + env(safe-area-inset-bottom, 0px));
   left: 50%;
   transform: translateX(-50%);
-  background: #fff;
-  box-shadow: 0 -10px 30px rgba(0, 0, 0, 0.08);
-  padding-bottom: max(0.75rem, env(safe-area-inset-bottom, 0.5rem));
   z-index: 100;
+  pointer-events: none;
 }
 
 .navIcons {
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  max-width: 420px;
-  margin: 0 auto;
-  padding: 0.5rem 2rem 0;
-  gap: 0.5rem;
+  gap: 4px;
+  padding: 6px;
+  border-radius: 9999px;
+  background: rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  box-shadow:
+    0 4px 24px rgba(0, 0, 0, 0.12),
+    0 1px 4px rgba(0, 0, 0, 0.08),
+    inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  pointer-events: auto;
 }
 
 .navIcon {
-  width: 56px;
+  width: 62px;
   height: 56px;
-  border-radius: 18px;
-  border: none;
-  background: #fff;
-  color: #454545;
+  border-radius: 9999px;
+  border: 1.5px solid transparent;
+  background: transparent;
+  color: rgba(80, 80, 90, 0.75);
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -37,11 +41,12 @@
   cursor: pointer;
 
   &:hover {
-    background: #f5f5f5;
+    background: rgba(255, 255, 255, 0.45);
+    color: #0ea5e9;
   }
 
   &:active {
-    transform: scale(0.95);
+    transform: scale(0.92);
   }
 }
 
@@ -52,12 +57,6 @@
 }
 
 .navIconActive {
-  background: #f0f9ff;
   color: #0ea5e9;
-}
-
-@media (max-width: 390px) {
-  .navIcons {
-    padding: 0.5rem 1.5rem 0;
-  }
+  background: rgba(255, 255, 255, 0.45);
 }


### PR DESCRIPTION
## 📌 Related Issue
<!-- 관련된 이슈 번호를 #과 함께 작성해주세요 -->
- Closes #161 

<br/>

## ✏️ Content
<!-- 작업한 내용을 간단히 설명해주세요 -->
- `BottomActionBar` 공유 UI 컴포넌트 추가 (아이콘 액션 + primary CTA 버튼 조합)
- `PlaceDetailPage` 하단 CTA 영역을 `BottomActionBar`로 교체 (좋아요 / 스크랩 / 내 플랜에 담기)
- 댓글 API 연동 — `comment.api.ts`, `useComments` 훅, `comment.types.ts` 추가
- `CourseViewPage` mock 데이터 제거 후 실 API 기반 댓글 로드 / 작성 / 삭제 / 좋아요 적용
- `BottomNavigation` 플로팅 pill 스타일 리뉴얼 (blur backdrop, 둥근 캡슐 형태)
- `.gitignore`에 `cc/input/*` 추가

<br/>

## 🗒️ 참고 사항
<!-- PR 승인 전 확인해야 할 사항들을 설명해주세요 (ex. 스크린샷, 코드) -->
- `BottomActionBar`는 `PlaceDetailPage` 외에도 재사용 가능한 공유 컴포넌트로 설계됨
- 댓글 API는 `/api/reply/{planId}` 엔드포인트 기준으로 연동 (백엔드 서버 `localhost:3845` 필요)
- `BottomNavigation` 스타일 변경으로 기존 하단 탭 UI가 달라지므로 전체 페이지 시각 확인 필요